### PR TITLE
Allow passing in array to $amplitude->event() to set properties on event

### DIFF
--- a/src/Amplitude.php
+++ b/src/Amplitude.php
@@ -188,7 +188,8 @@ class Amplitude
      *
      * You can also pass in an event to set as the next event to run.
      *
-     * @param null|\Zumba\Amplitude\Event Can pass in an event to set as the next event to run
+     * @param null|array|\Zumba\Amplitude\Event Can pass in an event to set as the next event to run, or array to set
+     *   properties on that event
      * @return \Zumba\Amplitude\Event
      */
     public function event($event = null)
@@ -198,6 +199,10 @@ class Amplitude
         } elseif (empty($this->event)) {
             // Set the values that persist between tracking events
             $this->event = new Event();
+        }
+        if (!empty($event) && is_array($event)) {
+            // Set properties on the event
+            $this->event->set($event);
         }
         return $this->event;
     }

--- a/test/AmplitudeTest.php
+++ b/test/AmplitudeTest.php
@@ -78,6 +78,14 @@ class AmplitudeTest extends \PHPUnit_Framework_TestCase
         $amplitude->event($event);
         $this->assertSame($event, $amplitude->event(), 'Event passed in should persist until it is used or reset');
         $this->assertNotSame($newEvent, $event, 'Should not keep using old event if pass in a new one');
+
+        $addPropertyEvent = $amplitude->event(['new property' => 'value']);
+        $this->assertSame($addPropertyEvent, $event, 'Should keep using same event, have not set the event yet');
+        $this->assertEquals(
+            'value',
+            $addPropertyEvent->get('new property'),
+            'Should allow passing in event properties to set them on the event'
+        );
     }
 
     public function testLogEvent()


### PR DESCRIPTION
This allows the `$amplitude->event()` method to accept an array instead of an event object, to set additional properties on the event.

Example:

``` php
$amplitude->event(['property' => 'value']);
```

Would set the property on the next event to be sent.
