### PR TITLE
Add user properties convenience methods

### DIFF
--- a/src/Amplitude.php
+++ b/src/Amplitude.php
@@ -348,15 +348,19 @@ class Amplitude
     /**
      * Add user properties, will be sent with the next event sent to Amplitude
      *
-     * If user properties are added to the event directly, these will be merged onto the event's user properties.
+     * If user properties are added to the event directly, these will be added on top, so the properties set directly
+     * on the Event object would take precedence.
      *
-     * If no events are logged after this point, it will not get sent to Amplitude
+     * If this is called multiple times before an event is sent, later calls will only add to the array, it will not
+     * overwrite values already set if no events have been sent yet.
+     *
+     * Note that if no events are logged after this point, it will not get sent to Amplitude
      *
      * @param array $userProperties
      */
     public function addUserProperties(array $userProperties)
     {
-        $this->userProperties = array_merge($this->userProperties, $userProperties);
+        $this->userProperties = $this->userProperties + $userProperties;
         return $this;
     }
 

--- a/src/Amplitude.php
+++ b/src/Amplitude.php
@@ -252,9 +252,7 @@ class Amplitude
             $event->deviceId = $this->deviceId;
         }
         if (!empty($this->userProperties)) {
-            $props = !empty($event->userProperties) ? $event->userProperties : [];
-            $props = array_merge($props, $this->userProperties);
-            $event->userProperties = $props;
+            $event->addUserProperties($this->userProperties);
             $this->resetUserProperties();
         }
 
@@ -348,9 +346,11 @@ class Amplitude
     }
 
     /**
-     * Set the user properties, will be sent with the next event sent to Amplitude
+     * Add user properties, will be sent with the next event sent to Amplitude
      *
-     * If no events are logged, it will not get sent to Amplitude
+     * If user properties are added to the event directly, these will be merged onto the event's user properties.
+     *
+     * If no events are logged after this point, it will not get sent to Amplitude
      *
      * @param array $userProperties
      */

--- a/src/Event.php
+++ b/src/Event.php
@@ -103,12 +103,17 @@ class Event implements \JsonSerializable
     /**
      * Add user properties
      *
+     * If called multiple times, the first time a user property is set will take precedence.
+     *
+     * If need to overwrite a property already set, you can manipulate $event->userProperties array directly
+     *
      * @param array $userProperties
+     * @return \Zumba\Amplitude\Event
      */
     public function addUserProperties(array $userProperties)
     {
         $props = !empty($this->userProperties) ? $this->userProperties : [];
-        $this->userProperties = array_merge($props, $userProperties);
+        $this->userProperties = $props + $userProperties;
         return $this;
     }
 

--- a/src/Event.php
+++ b/src/Event.php
@@ -100,6 +100,17 @@ class Event implements \JsonSerializable
         }
     }
 
+    /**
+     * Add user properties
+     *
+     * @param array $userProperties
+     */
+    public function addUserProperties(array $userProperties)
+    {
+        $props = !empty($this->userProperties) ? $this->userProperties : [];
+        $this->userProperties = array_merge($props, $userProperties);
+        return $this;
+    }
 
     /**
      * Set a value in the event.

--- a/test/AmplitudeTest.php
+++ b/test/AmplitudeTest.php
@@ -324,7 +324,7 @@ class AmplitudeTest extends \PHPUnit_Framework_TestCase
 
         $userProps2 = ['dob' => 'yesterday', 'name' => 'Baby'];
         $expected = [
-            'dob' => 'yesterday',
+            'dob' => 'tomorrow',
             'gender' => 'f',
             'name' => 'Baby',
         ];
@@ -332,7 +332,7 @@ class AmplitudeTest extends \PHPUnit_Framework_TestCase
         $this->assertSame(
             $expected,
             $amplitude->getUserProperties(),
-            'Second call to addUserProperties should overwrite properties with same-name but keep everything else intact'
+            'Second call to addUserProperties should only add new properties, not overwrite existing'
         );
     }
 }

--- a/test/AmplitudeTest.php
+++ b/test/AmplitudeTest.php
@@ -314,4 +314,25 @@ class AmplitudeTest extends \PHPUnit_Framework_TestCase
             ->queueEvent('Another Queued Event');
         $this->assertTrue($amplitude->getOptOut());
     }
+
+    public function testAddUserProperties()
+    {
+        $userProps = ['dob' => 'tomorrow', 'gender' => 'f'];
+        $amplitude = new Amplitude();
+        $amplitude->addUserProperties($userProps);
+        $this->assertSame($userProps, $amplitude->getUserProperties());
+
+        $userProps2 = ['dob' => 'yesterday', 'name' => 'Baby'];
+        $expected = [
+            'dob' => 'yesterday',
+            'gender' => 'f',
+            'name' => 'Baby',
+        ];
+        $amplitude->addUserProperties($userProps2);
+        $this->assertSame(
+            $expected,
+            $amplitude->getUserProperties(),
+            'Second call to addUserProperties should overwrite properties with same-name but keep everything else intact'
+        );
+    }
 }

--- a/test/EventTest.php
+++ b/test/EventTest.php
@@ -201,4 +201,29 @@ class EventTest extends \PHPUnit_Framework_TestCase
         unset($event->userId);
         $this->assertEmpty($event->userId, 'Should unset built-in properties with magic unset');
     }
+
+    public function testAddUserProperties()
+    {
+        $userProps = ['dob' => 'tomorrow', 'gender' => 'f'];
+        $event = new Event();
+        $event->addUserProperties($userProps);
+        $this->assertSame(
+            ['user_properties' => $userProps],
+            $event->toArray(),
+            'Should set user properties in user_properties'
+        );
+
+        $userProps2 = ['dob' => 'yesterday', 'name' => 'Baby'];
+        $expected = [
+            'dob' => 'yesterday',
+            'gender' => 'f',
+            'name' => 'Baby',
+        ];
+        $event->addUserProperties($userProps2);
+        $this->assertSame(
+            ['user_properties' => $expected],
+            $event->toArray(),
+            'Second call to addUserProperties should overwrite properties with same-name but keep everything else intact'
+        );
+    }
 }

--- a/test/EventTest.php
+++ b/test/EventTest.php
@@ -215,7 +215,7 @@ class EventTest extends \PHPUnit_Framework_TestCase
 
         $userProps2 = ['dob' => 'yesterday', 'name' => 'Baby'];
         $expected = [
-            'dob' => 'yesterday',
+            'dob' => 'tomorrow',
             'gender' => 'f',
             'name' => 'Baby',
         ];
@@ -223,7 +223,7 @@ class EventTest extends \PHPUnit_Framework_TestCase
         $this->assertSame(
             ['user_properties' => $expected],
             $event->toArray(),
-            'Second call to addUserProperties should overwrite properties with same-name but keep everything else intact'
+            'Second call to addUserProperties should only add new properties, not overwrite existing'
         );
     }
 }


### PR DESCRIPTION
This adds method `addUserProperties()` to event object, to easily add properties.  It also changes the behavior of `$amplitude->addUserProperties()` to only add new properties, not change ones already set, so there are no surprises with the name addUserProperties...
