### PR TITLE
Changing to use setUserProperties instead of addUserProperties

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ This is a moderately thin PHP API for [Amplitude](https://amplitude.com/), power
 // the user identifier or device identifier, and of course your Amplitude App API key)
 $amplitude = \Zumba\Amplitude\Amplitude::getInstance();
 $amplitude->init('APIKEY', 'johnny@example.com')
-    ->addUserProperties([
+    ->setUserProperties([
         'dob' => '1980-11-04',
         'name' => 'Johnny 5'
     ])
@@ -93,7 +93,7 @@ if ($canLogEvents) {
 There is one main way to set user properties, and this will send the user properties with the next Amplitude event sent to Amplitude:
 ```php
 \Zumba\Amplitude\Amplitude::getInstance()
-    ->addUserProperties(
+    ->setUserProperties(
         [
             'name' => 'Jane',
             'dob' => $dob,
@@ -105,27 +105,28 @@ You would typically call this right before calling `logQueuedEvents()` to make s
 
 Using this method, it only sends the user information with one event, since once a user property is set in Amplitude it persists for all events that match the user ID or event ID.
 
-Also note that if there happens to be no events sent after `addUserProperties()` are sent, those properties will not get sent to Amplitude.
+Also note that if there happens to be no events sent after `setUserProperties()` are sent, those properties will not get sent to Amplitude.
 
 One option, is to use a login event that adds the user info when the user has logged in, and sends it in a login event.  That way you only send user properties for the page load that the user logs in.
 
 Alternatively, just add the user properties with every page load when initializing the Amplitude object.  This is the option used in the examples.
 
 ## Adding User Properties on Event Object
-Another option for setting the user properties, is setting them on the Event object itself.  You can do this by setting `userProperties`, or by using the `addUserProperties()` method on the `Event` object.
+Another option for setting the user properties, is setting them on the Event object itself.  You can do this by setting/changing `userProperties`, or by using the `setUserProperties()` method on the `Event` object.
 
 You would typically use this in situations similar to the one in the next section, for times you may be sending events for different users in the same page load.
 
 ```php
 $event = new \Zumba\Amplitude\Event();
-// Method 1 - add user properties method:
-$event->addUserProperties(
+// Method 1 - set user properties method:
+$event->setUserProperties(
     [
         'name' => 'Rambo',
         // ...
     ]
 );
-// If you called addUserProperties() a second time, it would add any new properties but not affect ones already set
+// If you called setUserProperties() a second time, it would overwrite any properties with the same name but leave
+// others intact
 
 // Method 2 - just set the userProperties directly:
 $event->userProperties = [

--- a/src/Amplitude.php
+++ b/src/Amplitude.php
@@ -78,7 +78,7 @@ class Amplitude
      * <code>
      * // In user initialization section of app...
      * Zumba\Amplitude\Amplitude::getInstance()->init('APIKEY','johnny@example.com')
-     *     ->addUserProperties(['name' => 'Johnny 5'])
+     *     ->setUserProperties(['name' => 'Johnny 5'])
      *     ->logQueuedEvents();
      *
      * // Elsewhere in your app, this could happen before OR after the above initialization...
@@ -359,14 +359,14 @@ class Amplitude
      *
      * @param array $userProperties
      */
-    public function addUserProperties(array $userProperties)
+    public function setUserProperties(array $userProperties)
     {
         $this->userProperties = array_merge($this->userProperties, $userProperties);
         return $this;
     }
 
     /**
-     * Resets user properties added with addUserProperties() if they have not already been sent in an event to Amplitude
+     * Resets user properties added with setUserProperties() if they have not already been sent in an event to Amplitude
      *
      * @return \Zumba\Amplitude\Amplitude
      */
@@ -391,7 +391,7 @@ class Amplitude
      *
      * This resets the user ID, device ID previously set using setUserId or setDeviceId.
      *
-     * If additional information was previously set using addUserProperties() method, and the event has not already
+     * If additional information was previously set using setUserProperties() method, and the event has not already
      * been sent to Amplitude, it will reset that information as well.
      *
      * Does not reset user information if set manually on an individual event in the queue.

--- a/src/Amplitude.php
+++ b/src/Amplitude.php
@@ -257,9 +257,7 @@ class Amplitude
             $event->deviceId = $this->deviceId;
         }
         if (!empty($this->userProperties)) {
-            $props = !empty($event->userProperties) ? $event->userProperties : [];
-            $props = array_merge($props, $this->userProperties);
-            $event->userProperties = $props;
+            $event->setUserProperties($this->userProperties);
             $this->resetUserProperties();
         }
 
@@ -354,6 +352,8 @@ class Amplitude
 
     /**
      * Set the user properties, will be sent with the next event sent to Amplitude
+     *
+     * Any set with this will take precedence over any set on the Event object
      *
      * If no events are logged, it will not get sent to Amplitude
      *

--- a/src/Event.php
+++ b/src/Event.php
@@ -100,6 +100,17 @@ class Event implements \JsonSerializable
         }
     }
 
+    /**
+     * Set the user properties on the event
+     *
+     * @param array $userProperties
+     */
+    public function setUserProperties(array $userProperties)
+    {
+        $props = $this->userProperties ?: [];
+        $this->userProperties = array_merge($props, $userProperties);
+        return $this;
+    }
 
     /**
      * Set a value in the event.

--- a/test/AmplitudeTest.php
+++ b/test/AmplitudeTest.php
@@ -322,4 +322,24 @@ class AmplitudeTest extends \PHPUnit_Framework_TestCase
             ->queueEvent('Another Queued Event');
         $this->assertTrue($amplitude->getOptOut());
     }
+
+    public function testSetUserProperties()
+    {
+        $userProps = ['dob' => 'tomorrow', 'gender' => 'f'];
+        $amplitude = new Amplitude();
+        $amplitude->setUserProperties($userProps);
+        $this->assertSame($userProps, $amplitude->getUserProperties());
+        $userProps2 = ['dob' => 'yesterday', 'name' => 'Baby'];
+        $expected = [
+            'dob' => 'yesterday',
+            'gender' => 'f',
+            'name' => 'Baby',
+        ];
+        $amplitude->setUserProperties($userProps2);
+        $this->assertSame(
+            $expected,
+            $amplitude->getUserProperties(),
+            'Second call to setUserProperties should set properties, without removing existing'
+        );
+    }
 }

--- a/test/AmplitudeTest.php
+++ b/test/AmplitudeTest.php
@@ -154,7 +154,7 @@ class AmplitudeTest extends \PHPUnit_Framework_TestCase
         $event = $amplitude->event();
         $event->userProperties = $props;
         $result = $amplitude->init('APIKEY', $userId)
-            ->addUserProperties($props2)
+            ->setUserProperties($props2)
             ->logEvent($eventType);
 
         $eventData = $event->toArray();
@@ -291,7 +291,7 @@ class AmplitudeTest extends \PHPUnit_Framework_TestCase
         $amplitude = new Amplitude();
         $amplitude->setUserId('User')
             ->setDeviceId('device')
-            ->addUserProperties(['user props']);
+            ->setUserProperties(['user props']);
         $this->assertNotEmpty($amplitude->getUserId(), 'Initialization check');
         $this->assertNotEmpty($amplitude->getDeviceId(), 'Initialization check');
         $this->assertNotEmpty($amplitude->getUserProperties(), 'Initialization check');

--- a/test/EventTest.php
+++ b/test/EventTest.php
@@ -201,4 +201,28 @@ class EventTest extends \PHPUnit_Framework_TestCase
         unset($event->userId);
         $this->assertEmpty($event->userId, 'Should unset built-in properties with magic unset');
     }
+
+    public function testSetUserProperties()
+    {
+        $userProps = ['dob' => 'tomorrow', 'gender' => 'f'];
+        $event = new Event();
+        $event->setUserProperties($userProps);
+        $this->assertSame(
+            ['user_properties' => $userProps],
+            $event->toArray(),
+            'Should set user properties in user_properties'
+        );
+        $userProps2 = ['dob' => 'yesterday', 'name' => 'Baby'];
+        $expected = [
+            'dob' => 'yesterday',
+            'gender' => 'f',
+            'name' => 'Baby',
+        ];
+        $event->setUserProperties($userProps2);
+        $this->assertSame(
+            ['user_properties' => $expected],
+            $event->toArray(),
+            'Second call to setUserProperties should update properties, not remove existing'
+        );
+    }
 }


### PR DESCRIPTION
As discussed in #9 this changes things to use `setUserProperties()` to be consistent with the JS SDK and hopefully not be as confusing.
