### PR TITLE
fix(doc): add return type for setUserProperties

### DIFF
--- a/src/Amplitude.php
+++ b/src/Amplitude.php
@@ -359,6 +359,7 @@ class Amplitude
      * If no events are logged, it will not get sent to Amplitude
      *
      * @param array $userProperties
+     * @return \Zumba\Amplitude\Amplitude
      */
     public function setUserProperties(array $userProperties)
     {


### PR DESCRIPTION
I noticed setUserProperties was missing a return type which caused issues with [Psalm](https://psalm.dev/).