### PR TITLE
chore(php): update to supported versions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,19 +2,17 @@ language: php
 sudo: false
 
 php:
-  - 5.4
-  - 5.5
-  - 5.6
-  - 7.0
-  - hhvm
+  - 7.2
+  - 7.3
+  - 7.4
 
 before_script:
-  - if [ $TRAVIS_PHP_VERSION = '7.0' ]; then composer require satooshi/php-coveralls; fi
+  - composer require satooshi/php-coveralls
   - composer install --dev
 
 script:
-  - if [ $TRAVIS_PHP_VERSION = '7.0' ]; then vendor/bin/phpunit --coverage-clover build/logs/clover.xml; else vendor/bin/phpunit; fi
-  - if [ $TRAVIS_PHP_VERSION = '7.0' ]; then ./vendor/bin/phpcs --standard=psr2 src test; fi
+  - vendor/bin/phpunit --coverage-clover build/logs/clover.xml
+  - ./vendor/bin/phpcs --standard=psr2 src test
 
 after_success:
-  - if [ $TRAVIS_PHP_VERSION = '7.0' ]; then php vendor/bin/coveralls; fi
+  - php vendor/bin/coveralls

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,6 @@ sudo: false
 php:
   - 7.2
   - 7.3
-  - 7.4
 
 before_script:
   - composer require satooshi/php-coveralls

--- a/composer.json
+++ b/composer.json
@@ -16,7 +16,7 @@
         }
     ],
     "require": {
-        "php": ">=5.4",
+        "php": ">=7.2",
         "psr/log": "^1.0"
     },
     "require-dev": {


### PR DESCRIPTION
Travis is failing HHVM, but it's worth updating to only the supported versions of >= PHP 7.2. This will allow us to use return types in the code as well, but obviously requires a version bump.

7.4 isn't working with Travis just yet it seems, so excluding that for now.