### PR TITLE
Use new domain for SSL root expiration

### DIFF
--- a/src/Amplitude.php
+++ b/src/Amplitude.php
@@ -7,7 +7,7 @@ class Amplitude
 {
     use Log\LoggerAwareTrait;
 
-    const AMPLITUDE_API_URL = 'https://api.amplitude.com/httpapi';
+    const AMPLITUDE_API_URL = 'https://api2.amplitude.com/httpapi';
 
     const EXCEPTION_MSG_NO_API_KEY = 'API Key is required to log an event';
     const EXCEPTION_MSG_NO_EVENT_TYPE = 'Event Type is required to log or queue an event';


### PR DESCRIPTION
I am just adding this PR just in case...the old endpoint does not work for my environment anymore, and this is the easiest way for me to fix the problem.

https://status.amplitude.com/incidents/lf2pwqnyrn6s

https://support.sectigo.com/articles/Knowledge/Sectigo-AddTrust-External-CA-Root-Expiring-May-30-2020

https://news.ycombinator.com/item?id=23362759