### PR TITLE
Fix PHP 8.1 warnings

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -17,6 +17,7 @@
     ],
     "require": {
         "ext-curl": "*",
+        "ext-json": "*",
         "php": ">=7.2",
         "psr/log": "^1.0 | ^2.0"
     },

--- a/src/Event.php
+++ b/src/Event.php
@@ -321,8 +321,7 @@ class Event implements \JsonSerializable
      *
      * @return array
      */
-    public function jsonSerialize()
-    {
+    public function jsonSerialize(): array {
         return $this->data;
     }
 }

--- a/src/Event.php
+++ b/src/Event.php
@@ -321,7 +321,8 @@ class Event implements \JsonSerializable
      *
      * @return array
      */
-    public function jsonSerialize(): array {
+    public function jsonSerialize(): array
+    {
         return $this->data;
     }
 }


### PR DESCRIPTION
Using this library on PHP 8.1 produces the following warning:

> Deprecated: Return type of Zumba\Amplitude\Event::jsonSerialize() should either be compatible with JsonSerializable::jsonSerialize(): mixed, or the #[\ReturnTypeWillChange] attribute should be used to temporarily suppress the notice in /my/package/vendor/zumba/amplitude-php/src/Event.php on line 324

Also this package should explicitly declare its dependency on the JSON extension.